### PR TITLE
Fix link generation

### DIFF
--- a/subs
+++ b/subs
@@ -62,8 +62,8 @@ gen_links() {
         esac
 
         # otherwise we are given a username, we must find out its channel ID
-        curl -sfL --retry 10 "https://youtube.com/user/$line/about" | grep channel_id | \
-            sed -e 's|www\.||' -e 's|.*href="||' -e 's|">.*||' >>"$SUBS_LINKS"
+	curl -sfL --retry 10 "https://youtube.com/user/$line/about" | \
+		echo "https://youtube.com/feeds/videos.xml?channel_id=$(grep -ohm 1 'channel\/UC......................' | tail -c 25)" >>"$SUBS_LINKS"
 
     done <"$SUBS_FILE"
 }


### PR DESCRIPTION
Fixes the problem mentioned in #2 and #3.

The old method which channel IDs were obtained via username was unreliable. 
Occasionally it resulted in a big blob of json being put into your links file. 

This patch fixes that by using a different method to get the channel ID from a username.