### PR TITLE
Substitute HTML escape codes when piping into menu

### DIFF
--- a/subs
+++ b/subs
@@ -169,7 +169,8 @@ cat_subs() {
 # Finally, play the result with mpv.
 get_sel() {
     if [ -d "$SUBS_CACHE" ] ; then
-        sel=$(cat_subs | $SUBS_MENU_PROG)
+	# Pipe your subs feed into your desired menu and replace HTML escape codes (&quot; -> ")
+        sel=$(cat_subs | sed -e 's/&quot;/"/g' -e 's/&amp;/\&/g' -e 's/&lt;/</g' -e 's/&gt;/>/g' | $SUBS_MENU_PROG)
     else
         die 'Subs cache has not been retrieved.'
     fi

--- a/subs
+++ b/subs
@@ -169,7 +169,7 @@ cat_subs() {
 # Finally, play the result with mpv.
 get_sel() {
     if [ -d "$SUBS_CACHE" ] ; then
-	# Pipe your subs feed into your desired menu and replace HTML escape codes (&quot; -> ")
+        # Pipe your subs feed into your desired menu and replace HTML escape codes (&quot; -> ")
         sel=$(cat_subs | sed -e 's/&quot;/"/g' -e 's/&amp;/\&/g' -e 's/&lt;/</g' -e 's/&gt;/>/g' | $SUBS_MENU_PROG)
     else
         die 'Subs cache has not been retrieved.'

--- a/subs
+++ b/subs
@@ -177,9 +177,9 @@ get_sel() {
 
     [ "$sel" ] || die Interrupted
 
-    chan="${sel#* }"
-    chan="${chan%%] *}"
-    title=${sel#*"$chan"\] }
+    oldchan="${sel#* }"
+    chan=$(printf "${oldchan%%] *}" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
+    title=$(printf "${sel#*"${oldchan%%] *}"\] }" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
     while read -r line ; do
         case $line in
             *"$SEP$title$SEP"*)

--- a/subs
+++ b/subs
@@ -178,8 +178,8 @@ get_sel() {
     [ "$sel" ] || die Interrupted
 
     oldchan="${sel#* }"
-    chan=$(printf "${oldchan%%] *}" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
-    title=$(printf "${sel#*"${oldchan%%] *}"\] }" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
+    chan=$(printf '%s' "${oldchan%%] *}" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
+    title=$(printf '%s' "${sel#*"${oldchan%%] *}"\] }" | sed -e 's/\&/&amp;/g' -e 's/"/\&quot;/g'  -e 's/</\&lt;/g' -e 's/>/\&gt;/g' )
     while read -r line ; do
         case $line in
             *"$SEP$title$SEP"*)


### PR DESCRIPTION
Example:
![1591851771](https://user-images.githubusercontent.com/34148527/84347044-8c398e80-ab7f-11ea-864b-080982db3277.png)
![1591851756](https://user-images.githubusercontent.com/34148527/84347046-8e035200-ab7f-11ea-93e8-64eb8e088669.png)
(I am using `fzf` instead of `dmenu`)

Characters like `"`, `&`, `<`, and `>` (probably some more too, these ones are most common) would appear as their [escape codes in HTML](https://ascii.cl/htmlcodes.htm) like `&quot;`, `&amp;`, `&lt;`, and `&gt;`.

This patch runs a simple sed command on the output of `cat_subs` before piping into your desired program in order to restore the escaped characters.